### PR TITLE
Update CanvasUtil.cs

### DIFF
--- a/Assembly-CSharp/CanvasUtil.cs
+++ b/Assembly-CSharp/CanvasUtil.cs
@@ -433,7 +433,7 @@ namespace Modding
         {
             GameObject panel = CreateBasePanel(parent, rectData);
 
-            CreateTextPanel(panel, text, fontSize, textAnchor, rectData, bold);
+            CreateTextPanel(panel, text, fontSize, textAnchor, new RectData(new Vector2(0,0), new Vector2(0,0)), bold);
 
             Image img = panel.AddComponent<Image>();
             img.sprite = spr;


### PR DESCRIPTION
fix error causing rectData to be applied to both parent (button) and child (text) object in the CreateButton function