### PR TITLE
Add a vector to DashVectorHook method so mods can get the original

### DIFF
--- a/Assembly-CSharp/Handlers.cs
+++ b/Assembly-CSharp/Handlers.cs
@@ -160,7 +160,7 @@ namespace Modding
     /// Called during dash function to change velocity
     /// </summary>
     /// <returns>New vector for velocity</returns>
-    public delegate Vector2 DashVelocityHandler();
+    public delegate Vector2 DashVelocityHandler(Vector2 change);
 
     /// <summary>
     /// Called whenever the dash key is pressed. Overrides normal dash functionalit

--- a/Assembly-CSharp/ModHooks.cs
+++ b/Assembly-CSharp/ModHooks.cs
@@ -20,7 +20,7 @@ namespace Modding
     {
         internal static bool IsInitialized;
 
-        private const int _modVersion = 42;
+        private const int _modVersion = 43;
 
         /// <summary>
         /// Contains the seperator for path's, useful for handling Mac vs Windows vs Linux
@@ -1169,20 +1169,18 @@ namespace Modding
         /// Called during dash function to change velocity
         /// </summary>
         /// <remarks>HeroController.Dash</remarks>
-        internal Vector2? DashVelocityChange()
+        internal Vector2 DashVelocityChange(Vector2 change)
         {
             Logger.LogFine( "[API] - DashVelocityChange Invoked" );
 
-            if( _DashVectorHook == null ) return null;
-
-            Vector2? change = null;
+            if( _DashVectorHook == null ) return change;
 
             Delegate[] invocationList = _DashVectorHook.GetInvocationList();
             foreach( Delegate toInvoke in invocationList )
             {
                 try
                 {
-                    change = (Vector2)toInvoke.DynamicInvoke();
+                    change = (Vector2)toInvoke.DynamicInvoke( change );
                 }
                 catch( Exception ex )
                 {


### PR DESCRIPTION
dash vector before changing it. This makes DashVectorHook better resemble the other hooks that require returning an output.

This also makes the modding api 0.0002% more efficient when dashing becasue the following code is no longer called twice in a row in the absence of a mod using this hook:

    AffectedByGravity(false);
    ResetHardLandingTimer();
    if (dash_timer > DASH_TIME)
    {
        FinishedDashing();
        return;
    }
