### PR TITLE
Change return type of DashPressed to bool cause that makes sense

### DIFF
--- a/Assembly-CSharp/Handlers.cs
+++ b/Assembly-CSharp/Handlers.cs
@@ -165,7 +165,7 @@ namespace Modding
     /// <summary>
     /// Called whenever the dash key is pressed. Overrides normal dash functionalit
     /// </summary>
-    public delegate void DashPressedHandler();
+    public delegate bool DashPressedHandler();
 
     /// <summary>
     /// Called whenever a new gameobject is created with a collider and playmaker2d

--- a/Assembly-CSharp/ModHooks.cs
+++ b/Assembly-CSharp/ModHooks.cs
@@ -1222,13 +1222,15 @@ namespace Modding
             Logger.LogFine( "[API] - OnDashPressed Invoked" );
 
             if( _DashPressedHook == null ) return false;
+
+            bool ret;
             
             Delegate[] invocationList = _DashPressedHook.GetInvocationList();
             foreach( Delegate toInvoke in invocationList )
             {
                 try
                 {
-                    toInvoke.DynamicInvoke();
+                    ret = (bool) toInvoke.DynamicInvoke();
                 }
                 catch( Exception ex )
                 {
@@ -1236,7 +1238,7 @@ namespace Modding
                 }
             }
 
-            return true;
+            return ret;
         }
 
         #endregion


### PR DESCRIPTION
Changes the base functionality of the hook so it returns whether or not the original dash should be overriden.