### PR TITLE
 Change return type of DashPressed to bool cause that makes sense

### DIFF
--- a/Assembly-CSharp/Handlers.cs
+++ b/Assembly-CSharp/Handlers.cs
@@ -165,7 +165,7 @@ namespace Modding
     /// <summary>
     /// Called whenever the dash key is pressed. Overrides normal dash functionalit
     /// </summary>
-    public delegate void DashPressedHandler();
+    public delegate bool DashPressedHandler();
 
     /// <summary>
     /// Called whenever a new gameobject is created with a collider and playmaker2d

--- a/Assembly-CSharp/ModHooks.cs
+++ b/Assembly-CSharp/ModHooks.cs
@@ -1192,10 +1192,10 @@ namespace Modding
         }
 
         /// <summary>
-        /// Called whenever the dash key is pressed. Overrides normal dash functionality
+        /// Called whenever the dash key is pressed. Returns whether or not to override normal dash functionality
         /// </summary>
         /// <remarks>HeroController.LookForQueueInput</remarks>
-        [HookInfo("Called whenever the dash key is pressed. Overrides normal dash functionality", "HeroController.LookForQueueInput")]
+        [HookInfo("Called whenever the dash key is pressed. Returns whether or not to override normal dash functionality", "HeroController.LookForQueueInput")]
         public event DashPressedHandler DashPressedHook
         {
             add
@@ -1214,7 +1214,7 @@ namespace Modding
         private event DashPressedHandler _DashPressedHook;
 
         /// <summary>
-        /// Called whenever the dash key is pressed. Overrides normal dash functionality
+        /// Called whenever the dash key is pressed. Returns whether or not to override normal dash functionality
         /// </summary>
         /// <remarks>HeroController.LookForQueueInput</remarks>
         internal bool OnDashPressed()
@@ -1222,13 +1222,18 @@ namespace Modding
             Logger.LogFine( "[API] - OnDashPressed Invoked" );
 
             if( _DashPressedHook == null ) return false;
+
+            bool ret = false;
             
             Delegate[] invocationList = _DashPressedHook.GetInvocationList();
             foreach( Delegate toInvoke in invocationList )
             {
                 try
                 {
-                    toInvoke.DynamicInvoke();
+                    if ((bool) toInvoke.DynamicInvoke())
+                    {
+                        ret = true;
+                    }
                 }
                 catch( Exception ex )
                 {
@@ -1236,7 +1241,7 @@ namespace Modding
                 }
             }
 
-            return true;
+            return ret;
         }
 
         #endregion


### PR DESCRIPTION
Changes the base functionality of the hook so it returns whether or not the original dash should be overriden.