### PR TITLE
Fixes the error where msbuild could detect the API as .NET 4

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -152,6 +152,9 @@
             <SpecificVersion>False</SpecificVersion>
             <HintPath>..\Vanilla\PlayMaker.dll</HintPath>
         </Reference>
+	<Reference Include="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+	      <HintPath>..\Vanilla\mscorlib.dll</HintPath>
+	</Reference>
         <Reference Include="System">
             <HintPath>..\Vanilla\System.dll</HintPath>
         </Reference>


### PR DESCRIPTION
the fact that this works is gay