### PR TITLE
Fix UpdateBlueHealth()

### DIFF
--- a/Assembly-CSharp/Patches/PlayerData.cs
+++ b/Assembly-CSharp/Patches/PlayerData.cs
@@ -212,8 +212,8 @@ namespace Modding.Patches
 
         public void UpdateBlueHealth()
         {
-            healthBlue = ModHooks.Instance.OnBlueHealth();
             orig_UpdateBlueHealth();
+            healthBlue += ModHooks.Instance.OnBlueHealth();
         }
     
         [MonoModOriginalName("AddHealth")]


### PR DESCRIPTION
Simple fix for the blue health hook which currently does nothing. orig_UpdateBlueHealth() needs to be called before the hooks because orig_UpdateBlueHealth() immediately sets blue health to 0 before checking charms.